### PR TITLE
Improvment work with redis cluster disconnections

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ set (ASYNC async)
 set (ASYNCERR asyncerr)
 set (TEST testing)
 set (SYNC sync)
+set (SYNC_DISCONNECT sync_disconnect)
 set (UNIXSOCK unix)
 set (THREADEDPOOL threadedpool)
 
@@ -40,6 +41,9 @@ set(ASYNC_SOURCES
 set(SYNC_SOURCES
         src/examples/example.cpp)
 
+set(SYNC_DISCONNECT_SOURCES
+        src/examples/example_disconnect.cpp)
+
 set(UNIX_SOURCES
         src/examples/unixsocketexample.cpp)
 
@@ -56,6 +60,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY bin/)
 
 add_executable (${ASYNC} ${HEADERS} ${ASYNC_SOURCES})
 add_executable (${SYNC} ${HEADERS} ${SYNC_SOURCES})
+add_executable (${SYNC_DISCONNECT} ${HEADERS} ${SYNC_DISCONNECT_SOURCES})
 add_executable (${TEST} ${HEADERS} ${TEST_SOURCES})
 add_executable (${UNIXSOCK} ${HEADERS} ${UNIX_SOURCES})
 add_executable (${ASYNCERR} ${HEADERS} ${ASYNCERR_SOURCES})
@@ -74,4 +79,5 @@ target_link_libraries (${THREADEDPOOL} libhiredis.so libpthread.so)
 endif(USE_CLANG)
 
 target_link_libraries (${SYNC} libhiredis.a)
+target_link_libraries (${SYNC_DISCONNECT} libhiredis.a)
 target_link_libraries (${UNIXSOCK} libhiredis.a)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 2.8)
 set (ASYNC async)
+set (ASYNC_DISCONNECT async_disconnect)
 set (ASYNCERR asyncerr)
 set (TEST testing)
 set (SYNC sync)
@@ -31,12 +32,16 @@ set(HEADERS
 	include/hirediscommand.h
 	include/hiredisprocess.h
 	include/slothash.h
-	include/clusterexception.h)
+	include/clusterexception.h
+    include/disconnectedconnections.h)
 
 include_directories(include)
 
 set(ASYNC_SOURCES
         src/examples/asyncexample.cpp)
+
+set(ASYNC_DISCONNECT_SOURCES
+        src/examples/asyncexample_disconnect.cpp)
 
 set(SYNC_SOURCES
         src/examples/example.cpp)
@@ -59,6 +64,7 @@ set(THREADEDPOOL_SOURCES
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY bin/)
 
 add_executable (${ASYNC} ${HEADERS} ${ASYNC_SOURCES})
+add_executable (${ASYNC_DISCONNECT} ${HEADERS} ${ASYNC_DISCONNECT_SOURCES})
 add_executable (${SYNC} ${HEADERS} ${SYNC_SOURCES})
 add_executable (${SYNC_DISCONNECT} ${HEADERS} ${SYNC_DISCONNECT_SOURCES})
 add_executable (${TEST} ${HEADERS} ${TEST_SOURCES})
@@ -68,11 +74,13 @@ add_executable (${THREADEDPOOL} ${HEADERS} ${THREADEDPOOL_SOURCES})
 
 if(USE_CLANG)
 target_link_libraries (${ASYNC} libhiredis.dylib libevent.dylib)
+target_link_libraries (${ASYNC_DISCONNECT} libhiredis.dylib libevent.dylib)
 target_link_libraries (${TEST} libhiredis.dylib libevent.dylib)
 target_link_libraries (${ASYNCERR} libhiredis.dylib libevent.dylib)
 target_link_libraries (${THREADEDPOOL} libhiredis.dylib)
 else(USE_CLANG)
 target_link_libraries (${ASYNC} libhiredis.so libevent.so librt.so libpthread.so)
+target_link_libraries (${ASYNC_DISCONNECT} libhiredis.so libevent.so librt.so libpthread.so)
 target_link_libraries (${TEST} libhiredis.so libevent.so librt.so libpthread.so)
 target_link_libraries (${ASYNCERR} libhiredis.so libevent.so librt.so libpthread.so)
 target_link_libraries (${THREADEDPOOL} libhiredis.so libpthread.so)

--- a/include/disconnectedconnections.h
+++ b/include/disconnectedconnections.h
@@ -1,0 +1,57 @@
+#ifndef __libredisCluster__disconnectedconnections__
+#define __libredisCluster__disconnectedconnections__
+
+#include <vector>
+#include <algorithm> 
+
+extern "C"
+{
+#include <hiredis/hiredis.h>
+#include <hiredis/async.h>
+}
+
+namespace RedisCluster
+{
+    // Class is singleton
+    // Keeps pointers to disconnected and freed by hiredis library connection contexts
+    class DisconnectedConnections
+    {
+        typedef redisAsyncContext Connection;
+        typedef std::vector<const Connection*> Connections;
+        
+    private:
+        DisconnectedConnections() {}
+        DisconnectedConnections(const DisconnectedConnections&) = delete;        
+        DisconnectedConnections& operator=(const DisconnectedConnections&) = delete;
+        
+    public:
+        static DisconnectedConnections& getInstance() {
+            static DisconnectedConnections instance;
+            return instance;
+        }    
+    
+        void addConnection(const Connection *connection)
+        {
+            connections_.push_back(connection);
+        }
+        
+        void delConnection(const Connection* connection)
+        {
+            Connections::iterator it = std::find(connections_.begin(), connections_.end(), connection);
+            if (it != connections_.end()) {
+                connections_.erase(it);                
+            }
+        }
+        
+        bool isConnectionDisconnnected(const Connection* connection)
+        {
+            Connections::iterator it = std::find(connections_.begin(), connections_.end(), connection);
+            return it != connections_.end();
+        }
+    private:
+       
+        Connections connections_;
+    };
+}
+
+#endif // __libredisCluster__disconnectedconnections__

--- a/include/hirediscommand.h
+++ b/include/hirediscommand.h
@@ -146,8 +146,14 @@ namespace RedisCluster
         }
         
         redisReply* processHiredisCommand( Connection *con )
-        {
-            redisReply* reply;
+        {            
+            /* reply should be initialized there
+             * or checkCritical() will not throw DisconnectedException
+             * in case redis server was disconnected */
+            /* to reproduce segfault:
+             * replace nullptr with (redisReply*)123
+             * and run bin/sync_disconnect example */
+            redisReply* reply = nullptr;
             redisAppendFormattedCommand( con, cmd_, len_ );
             redisGetReply( con, (void**)&reply );
             return reply;

--- a/src/examples/asyncexample_disconnect.cpp
+++ b/src/examples/asyncexample_disconnect.cpp
@@ -1,0 +1,87 @@
+#include <iostream>
+#include <event2/event.h>
+#include <signal.h>
+#include <unistd.h>
+
+#include "asynchirediscommand.h"
+
+using RedisCluster::AsyncHiredisCommand;
+using RedisCluster::Cluster;
+
+using std::string;
+using std::out_of_range;
+using std::cerr;
+using std::cout;
+using std::endl;
+
+static void setCallback( typename Cluster<redisAsyncContext>::ptr_t cluster_p, void *r, void *data )
+{
+    redisReply * reply = static_cast<redisReply*>( r );
+    
+    if (!reply) {
+        cout << " Empty reply..." << endl;
+        return;
+    }
+    
+    if( reply->type == REDIS_REPLY_STATUS  || reply->type == REDIS_REPLY_ERROR )
+    {
+        cout << " Reply to SET FOO BAR " << endl;
+        cout << reply->str << endl;
+    }
+}
+
+void processAsyncCommand()
+{
+    Cluster<redisAsyncContext>::ptr_t cluster_p;
+    
+    signal(SIGPIPE, SIG_IGN);
+    struct event_base *base = event_base_new();
+    
+    cluster_p = AsyncHiredisCommand<>::createCluster( "127.0.0.1", 7000, static_cast<void*>( base ) );
+    
+    try {
+        
+        int lastsecond;
+        for (int i=0 ; i<100 ; )
+        {
+            if (lastsecond != time(NULL)) {
+                lastsecond = time(NULL);
+                ++i;
+                
+                cout << ">>> Loop iteration: " << i << endl;
+                cout << ">>> Stop or kill redis cluster to emulate cluster disconnection" << endl;                
+        
+                AsyncHiredisCommand<>::Command( cluster_p,
+                                             "FOO",
+                                             setCallback,
+                                             nullptr,
+                                             "SET %s %s",
+                                             "FOO",
+                                             "BAR1" );
+            }
+                        
+            event_base_loop(base, EVLOOP_NONBLOCK | EVLOOP_ONCE);                        
+            usleep(1000);
+        }        
+    } catch ( const RedisCluster::ClusterException &e )
+    {
+        cout << "Cluster exception: " << e.what() << endl;        
+    }
+    
+    cluster_p->disconnect();
+    delete cluster_p;
+    event_base_free(base);
+}
+
+int main(int argc, const char * argv[])
+{
+    try
+    {
+        processAsyncCommand();
+    } catch ( const RedisCluster::ClusterException &e )
+    {
+        cout << "Cluster exception: " << e.what() << endl;
+    }
+    return 0;
+}
+

--- a/src/examples/example_disconnect.cpp
+++ b/src/examples/example_disconnect.cpp
@@ -21,7 +21,8 @@ void processClusterCommand()
     
     for (int i=0 ; i<100 ; ++i)
     {
-        cout << "Loop iteration: " << i << endl;
+        cout << ">>> Loop iteration: " << i << endl;
+        cout << ">>> Stop or kill redis cluster to emulate cluster disconnection" << endl;
         
         reply = static_cast<redisReply*>( HiredisCommand<>::Command( cluster_p, "FOO", "SET %s %s", "FOO", "BAR1" ) );
         
@@ -32,11 +33,7 @@ void processClusterCommand()
         }
         
         freeReplyObject( reply );
-
-        cout << "Sleep..." << endl;
-        cout << "Stopping redis-server can cause segmentation fault" << endl;
-        cout << "Check it, try killall redis-server" << endl;
-        
+       
         sleep(1);
     }    
     

--- a/src/examples/example_disconnect.cpp
+++ b/src/examples/example_disconnect.cpp
@@ -1,0 +1,57 @@
+#include <iostream>
+#include <queue>
+#include <thread>
+#include <assert.h>
+#include <unistd.h>
+
+#include "hirediscommand.h"
+
+using namespace RedisCluster;
+using std::string;
+using std::cout;
+using std::cerr;
+using std::endl;
+
+void processClusterCommand()
+{
+    Cluster<redisContext>::ptr_t cluster_p;
+    redisReply * reply;
+    
+    cluster_p = HiredisCommand<>::createCluster( "127.0.0.1", 7000 );
+    
+    for (int i=0 ; i<100 ; ++i)
+    {
+        cout << "Loop iteration: " << i << endl;
+        
+        reply = static_cast<redisReply*>( HiredisCommand<>::Command( cluster_p, "FOO", "SET %s %s", "FOO", "BAR1" ) );
+        
+        if( reply->type == REDIS_REPLY_STATUS  || reply->type == REDIS_REPLY_ERROR )
+        {
+            cout << " Reply to SET FOO BAR " << endl;
+            cout << reply->str << endl;
+        }
+        
+        freeReplyObject( reply );
+
+        cout << "Sleep..." << endl;
+        cout << "Stopping redis-server can cause segmentation fault" << endl;
+        cout << "Check it, try killall redis-server" << endl;
+        
+        sleep(1);
+    }    
+    
+    cluster_p->disconnect();
+    delete cluster_p;
+}
+
+int main(int argc, const char * argv[])
+{
+    try
+    {
+        processClusterCommand();
+    } catch ( const RedisCluster::ClusterException &e )
+    {
+        cout << "Cluster exception: " << e.what() << endl;
+    }
+    return 0;
+}


### PR DESCRIPTION
Added two examples to show issues with server disconnections:
examples/example_disconnect.cpp (bin/sync_disconnnect)
examples/asyncexample_disconnect.cpp (bin/async_disconnect)

How to reproduce:
Build examples with previous version of library (include folder).
Run examples and stop redis cluster (killall redis-server).
Segmentation fault should occurs.

Added proposed fixes for these issues.
Build and run examples with changes in library (include folder).
