### PR TITLE
Do not free the reply objects inside hiredis callbacks since the underlyring hiredis library will free them later.

### DIFF
--- a/include/asynchirediscommand.h
+++ b/include/asynchirediscommand.h
@@ -241,7 +241,7 @@ namespace RedisCluster
 
             try
             {
-                HiredisProcess::checkCritical(reply, false);
+                HiredisProcess::checkCritical(reply, false, false);
                 if( reply->type == REDIS_REPLY_STATUS && string(reply->str) == "OK" )
                 {
                     if( that->processHiredisCommand( that->con_.second ) != REDIS_OK )
@@ -287,7 +287,7 @@ namespace RedisCluster
             string host, port;
             
             try {
-                HiredisProcess::checkCritical( reply, false );
+                HiredisProcess::checkCritical( reply, false, false );
                 state = HiredisProcess::processResult( reply, host, port);
                 switch (state) {
                     case HiredisProcess::ASK:


### PR DESCRIPTION
This fixes the bug reported in #19.