### PR TITLE
fixed RedisCluster::HiredisProcess::checkCritical() call

### DIFF
--- a/include/hirediscommand.h
+++ b/include/hirediscommand.h
@@ -203,7 +203,7 @@ namespace RedisCluster
             HiredisProcess::checkCritical(reply, false, "", con.second);
             cluster_p_->releaseConnection( con );
 
-            HiredisProcess::processState state = HiredisProcess::processResult( reply, host, port);
+            HiredisProcess::processState state = HiredisProcess::processResult(reply, false, true, "", con.second);
             
             switch ( state ) {
                 case HiredisProcess::ASK:


### PR DESCRIPTION
At compile with included `hirediscommand.h` I got error:

```
/home/sb0y/projects/jobler-core/src/redis/include/hirediscommand.h:207:42: error: no matching function for call to ‘RedisCluster::HiredisProcess::checkCritical(redisReply*&, bool, const char [1], redisContext*&)’
             HiredisProcess::checkCritical(reply, false, "", con.second);
                                          ^
In file included from /home/sb0y/projects/jobler-core/src/redis/include/asynchirediscommand.h:38:0,
                 from /home/sb0y/projects/jobler-core/src/session.cpp:13:
/home/sb0y/projects/jobler-core/src/redis/include/hiredisprocess.h:100:21: note: candidate: static void RedisCluster::HiredisProcess::checkCritical(redisReply*, bool, bool, std::__cxx11::string, redisContext*)
         static void checkCritical( redisReply *reply, bool errorcritical, bool free_reply_obj = true,
                     ^
/home/sb0y/projects/jobler-core/src/redis/include/hiredisprocess.h:100:21: note:   no known conversion for argument 4 from ‘redisContext*’ to ‘std::__cxx11::string {aka std::__cxx11::basic_string<char>}’
```